### PR TITLE
AHP-917 Upgrade code build project module version to v1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,16 @@ You can add the 1 line to the beginning of your `build` phase commands in `build
       - export GITHUB_TOKEN=${REPO_ACCESS_GITHUB_TOKEN_SECRETS_ID}
 ```
 
+## v1.8 Note
+If `use_repo_access_github_token` is set to `true`, the environment variable `REPO_ACCESS_GITHUB_TOKEN_SECRETS_ID` is exposed via codebuild.
+Usage remains the same as v1.6.
+If `s3_block_public_access` is set to `true`, the block public access setting for the artifact bucket is enabled.
+
 ## Usage
 
 ```hcl
 module "lambda_pipeline" {
-  source = "github.com/globeandmail/aws-codepipeline-lambda?ref=1.7"
+  source = "github.com/globeandmail/aws-codepipeline-lambda?ref=1.8"
 
   name               = app-name
   function_name      = lambda-function-name
@@ -29,8 +34,9 @@ module "lambda_pipeline" {
   tags = {
     Environment = var.environment
   }
-  central_account_github_token_aws_secret_arn = central-account-github-token-aws-secret-arn
-  central_account_github_token_aws_kms_cmk_arn = central-account-github-token-aws-kms-cmk-arn
+  use_repo_access_github_token = true
+  svcs_account_github_token_aws_secret_arn = svcs-account-github-token-aws-secret-arn
+  svcs_account_github_token_aws_kms_cmk_arn = svcs-account-github-token-aws-kms-cmk-arn
 }
 ```
 
@@ -49,9 +55,10 @@ module "lambda_pipeline" {
 | function\_alias | The name of the Lambda function alias that gets passed to the UserParameters data in the deploy stage | string | `"live"` | no |
 | deploy\_function\_name | The name of the Lambda function in the account that will update the function code | string | `"CodepipelineDeploy"` | no |
 | tags | A mapping of tags to assign to the resource | map | `{}` | no |
-| central\_account\_github\_token\_aws\_secret\_arn | \(Required\) The repo access Github token AWS secret ARN in the central AWS account | string | n/a | yes |
-| central\_account\_github\_token\_aws\_kms\_cmk\_arn | \(Required\) The repo access Github token AWS KMS customer managed key ARN in the central AWS account | string | n/a | yes |
-| create\_github\_webhook | Create the github webhook that triggers codepipeline | bool | `"true"` | no |
+| use\_repo\_access\_github\_token | \(Optional\) Allow the AWS codebuild IAM role read access to the REPO\_ACCESS\_GITHUB\_TOKEN secrets manager secret in the shared service account.<br>Defaults to false. | `bool` | `false` | no |
+| svcs\_account\_github\_token\_aws\_secret\_arn | \(Optional\) The AWS secret ARN for the repo access Github token.<br>The secret is created in the shared service account.<br>Required if var.use\_repo\_access\_github\_token is true. | `string` | `null` | no |
+| svcs\_account\_github\_token\_aws\_kms\_cmk\_arn | \(Optional\)  The us-east-1 region AWS KMS customer managed key ARN for encrypting the repo access Github token AWS secret.<br>The key is created in the shared service account.<br>Required if var.use\_repo\_access\_github\_token is true. | `string` | `null` | no |
+| s3\_block\_public\_access | \(Optional\) Enable the S3 block public access setting for the artifact bucket. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Creates a pipeline that generates a lambda zip archive and updates the existing 
 The account that owns the guthub token must have admin access on the repo in order to generate a github webhook 
 
 ## v1.6 Note
-The secrets manager environment variable `REPO_ACCESS_GITHUB_TOKEN_SECRETS_ID` is exposed via codebuild
+The secrets manager environment variable `REPO_ACCESS_GITHUB_TOKEN_SECRETS_ID` is exposed via codebuild.
 
 You can add the 1 line to the beginning of your `build` phase commands in `buildspec.yml` to assign the token's secret value to local variable `GITHUB_TOKEN`.
 
@@ -37,6 +37,7 @@ module "lambda_pipeline" {
   use_repo_access_github_token = true
   svcs_account_github_token_aws_secret_arn = svcs-account-github-token-aws-secret-arn
   svcs_account_github_token_aws_kms_cmk_arn = svcs-account-github-token-aws-kms-cmk-arn
+  s3_block_public_access = true
 }
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -12,15 +12,17 @@ locals {
 }
 
 module "codebuild_project" {
-  source = "github.com/globeandmail/aws-codebuild-project?ref=1.7"
+  source = "github.com/globeandmail/aws-codebuild-project?ref=1.8"
 
   name                                         = var.name
   deploy_type                                  = "lambda"
   tags                                         = var.tags
   privileged_mode                              = var.privileged_mode
   buildspec                                    = var.buildspec
-  central_account_github_token_aws_secret_arn  = var.central_account_github_token_aws_secret_arn
-  central_account_github_token_aws_kms_cmk_arn = var.central_account_github_token_aws_kms_cmk_arn
+  use_repo_access_github_token                 = var.use_repo_access_github_token
+  svcs_account_github_token_aws_secret_arn     = var.svcs_account_github_token_aws_secret_arn
+  svcs_account_github_token_aws_kms_cmk_arn    = var.svcs_account_github_token_aws_kms_cmk_arn
+  s3_block_public_access                       = var.s3_block_public_access
 }
 
 data "aws_iam_policy_document" "codepipeline_assume" {

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ locals {
 }
 
 module "codebuild_project" {
-  source = "github.com/globeandmail/aws-codebuild-project?ref=AHP-917"
+  source = "github.com/globeandmail/aws-codebuild-project?ref=1.8"
 
   name                                         = var.name
   deploy_type                                  = "lambda"

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ locals {
 }
 
 module "codebuild_project" {
-  source = "github.com/globeandmail/aws-codebuild-project?ref=1.8"
+  source = "github.com/globeandmail/aws-codebuild-project?ref=AHP-917"
 
   name                                         = var.name
   deploy_type                                  = "lambda"

--- a/variables.tf
+++ b/variables.tf
@@ -65,18 +65,43 @@ variable "tags" {
   default     = {}
 }
 
-variable "central_account_github_token_aws_secret_arn" {
-  type        = string
-  description = "(Required) The repo access Github token AWS secret ARN in the central AWS account"
+variable "use_repo_access_github_token" {
+  type        = bool
+  description = <<EOT
+                (Optional) Allow the AWS codebuild IAM role read access to the REPO_ACCESS_GITHUB_TOKEN secrets manager secret in the shared service account.
+                Defaults to false.
+                EOT
+  default     = false
 }
 
-variable "central_account_github_token_aws_kms_cmk_arn" {
+variable "svcs_account_github_token_aws_secret_arn" {
   type        = string
-  description = "(Required) The repo access Github token AWS KMS customer managed key ARN in the central AWS account"
+  description = <<EOT
+                (Optional) The AWS secret ARN for the repo access Github token.
+                The secret is created in the shared service account.
+                Required if var.use_repo_access_github_token is true.
+                EOT
+  default     = null
+}
+
+variable "svcs_account_github_token_aws_kms_cmk_arn" {
+  type        = string
+  description = <<EOT
+                (Optional) The us-east-1 region AWS KMS customer managed key ARN for encrypting the repo access Github token AWS secret.
+                The key is created in the shared service account.
+                Required if var.use_repo_access_github_token is true.
+                EOT
+  default     = null
 }
 
 variable "create_github_webhook" {
   type        = bool
   description = "Create the github webhook that triggers codepipeline. Defaults to true"
   default     = true
+}
+
+variable "s3_block_public_access" {
+  type = bool
+  description = "(Optional) Enable the S3 block public access setting for the artifact bucket."
+  default = false
 }


### PR DESCRIPTION
#### PR description

What is it for?
The PR is to upgrade the AWS code build project module version to v1.8.
 - add optional variables `use_repo_access_github_token` and `s3_block_public_access`.
 
#### Testing instructions

- Verify that the module version is upgraded to v1.8.

#### JIRA ticket information

Story: [AHP-917](https://jira.theglobeandmail.com/browse/AHP-917)